### PR TITLE
Cosmetic cleanup

### DIFF
--- a/test/test_command.py
+++ b/test/test_command.py
@@ -281,8 +281,8 @@ class TestRemoveExtra(unittest.TestCase):
     def test_remove_extra_packages_with_dashe_directive(self, mock_check_call, mock_check_output):
         mock_check_output.return_value = \
             'mock==1.2\nDjango==1.7\nnose==1.3\n ' \
-            '-e http://example.com/some-repo.git ' \
-            '\ndjango-nose==1.0\n'
+            '-e http://example.com/some-repo.git\n ' \
+            'django-nose==1.0\n'
         packages = _create_packages('mock==1.2\nDjango==1.7\nnose==1.3\n')
 
         self.command.remove_extra_packages(packages)


### PR DESCRIPTION
[Trying again; I forgot to rebase, which I hope is why the test coverage fractionally decreased on my last attempt.]

This is just a cosmetic fix -- making that string consistent as to where the "\n"s are in the source.

Sorry about all the noise...
