### PR TITLE
Add --dry-run option for --remove-extra

### DIFF
--- a/pipreq/cli.py
+++ b/pipreq/cli.py
@@ -20,6 +20,9 @@ def create_parser():
                         help='Upgrade packages (requires list of packages)')
     parser.add_argument('-x', '--remove-extra', action='store_true', default=False,
                         help='Remove packages not in list (requires list of packages)')
+    parser.add_argument('-n', '--dry-run', action='store_true', default=False,
+                        help='Don\'t actually make any changes; '
+                             'only show what would have been done')
     parser.add_argument('packages', nargs='?', type=argparse.FileType('r'), default=sys.stdin)
 
     return parser

--- a/pipreq/cli.py
+++ b/pipreq/cli.py
@@ -33,6 +33,8 @@ def verify_args(args):
                       ^ bool(args.remove_extra))
     if not has_one_option:
         return 'Must specify generate (-g) or create/upgrade/remove-missing (-[cux]) with packages'
+    if args.dry_run and not args.remove_extra:
+        return '-n is only supported with -x'
     return None
 
 

--- a/pipreq/command.py
+++ b/pipreq/command.py
@@ -226,7 +226,7 @@ class Command(object):
             print("No packages to upgrade")
 
     def determine_extra_packages(self, packages):
-        """ Return a packages that are installed, but missing from "packages".
+        """ Return all packages that are installed, but missing from "packages".
             Return value is a tuple of the package names """
 
         args = [

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -36,6 +36,21 @@ class TestCli(unittest.TestCase):
 
         self.assertEqual(None, error_message)
 
+    def test_verify_args_remove_extra_dry_run(self):
+        args = self.parser.parse_args(['-x', '-n'])
+
+        error_message = cli.verify_args(args)
+
+        self.assertEqual(None, error_message)
+
+    def test_verify_args_update_dry_run(self):
+        args = self.parser.parse_args(['-U', '-n'])
+
+        error_message = cli.verify_args(args)
+
+        expected_error = "-n is only supported with -x"
+        self.assertEqual(expected_error, error_message)
+
     @patch('argparse.ArgumentParser.exit')
     def test_error(self, mock_exit):
         cli.error(self.parser, 'An error occurred!')

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -262,8 +262,9 @@ class TestDetermineExtra(unittest.TestCase):
         mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\n'
         packages = _create_packages()
 
-        self.assertEqual((), self.command.determine_extra_packages(packages))
+        extras = self.command.determine_extra_packages(packages)
 
+        self.assertEqual((), extras)
         self.assertFalse(mock_check_call.called)
 
     @patch('subprocess.check_output')
@@ -272,8 +273,9 @@ class TestDetermineExtra(unittest.TestCase):
         mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\ndjango-nose==1.0\n'
         packages = _create_packages()
 
-        self.assertEqual(("django-nose",), self.command.determine_extra_packages(packages))
+        extras = self.command.determine_extra_packages(packages)
 
+        self.assertEqual(("django-nose",), extras)
         self.assertFalse(mock_check_call.called)
 
     @patch('subprocess.check_output')
@@ -286,8 +288,9 @@ class TestDetermineExtra(unittest.TestCase):
             'django-nose==1.0\n'
         packages = _create_packages('mock==1.2\nDjango==1.7\nnose==1.3\n')
 
-        self.assertEqual(("django-nose",), self.command.determine_extra_packages(packages))
+        extras = self.command.determine_extra_packages(packages)
 
+        self.assertEqual(("django-nose",), extras)
         self.assertFalse(mock_check_call.called)
 
 

--- a/test/test_command.py
+++ b/test/test_command.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from mock import MagicMock, patch
 import tempfile
 import unittest
@@ -249,6 +250,47 @@ class TestUpgrade(unittest.TestCase):
         mock_check_call.assert_called_once_with(['pip', 'install', '-U', 'mock', 'Django', 'nose'])
 
 
+class TestDetermineExtra(unittest.TestCase):
+    def setUp(self):
+        self.parser = cli.create_parser()
+        self.rc_file_blank = tempfile.NamedTemporaryFile()
+        self.command = command.Command(self.parser.parse_args([]), self.rc_file_blank.name)
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_determine_extra_packages_no_discrepancies(self, mock_check_call, mock_check_output):
+        mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\n'
+        packages = _create_packages()
+
+        self.assertEqual((), self.command.determine_extra_packages(packages))
+
+        self.assertFalse(mock_check_call.called)
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_determine_extra_packages(self, mock_check_call, mock_check_output):
+        mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\ndjango-nose==1.0\n'
+        packages = _create_packages()
+
+        self.assertEqual(("django-nose",), self.command.determine_extra_packages(packages))
+
+        self.assertFalse(mock_check_call.called)
+
+    @patch('subprocess.check_output')
+    @patch('subprocess.check_call')
+    def test_determine_extra_packages_with_dashe_directive(self,
+                                                           mock_check_call, mock_check_output):
+        mock_check_output.return_value = \
+            'mock==1.2\nDjango==1.7\nnose==1.3\n' \
+            '-e http://example.com/some-repo.git\n' \
+            'django-nose==1.0\n'
+        packages = _create_packages('mock==1.2\nDjango==1.7\nnose==1.3\n')
+
+        self.assertEqual(("django-nose",), self.command.determine_extra_packages(packages))
+
+        self.assertFalse(mock_check_call.called)
+
+
 class TestRemoveExtra(unittest.TestCase):
 
     def setUp(self):
@@ -258,7 +300,7 @@ class TestRemoveExtra(unittest.TestCase):
 
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')
-    def test_remove_extra_packages_no_discrepancies(self, mock_check_call, mock_check_output):
+    def test_remove_extra_packages_when_none_to_remove(self, mock_check_call, mock_check_output):
         mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\n'
         packages = _create_packages()
 
@@ -268,7 +310,7 @@ class TestRemoveExtra(unittest.TestCase):
 
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')
-    def test_remove_extra_packages(self, mock_check_call, mock_check_output):
+    def test_remove_extra_packages_when_some_to_remove(self, mock_check_call, mock_check_output):
         mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\ndjango-nose==1.0\n'
         packages = _create_packages()
 
@@ -278,16 +320,18 @@ class TestRemoveExtra(unittest.TestCase):
 
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')
-    def test_remove_extra_packages_with_dashe_directive(self, mock_check_call, mock_check_output):
-        mock_check_output.return_value = \
-            'mock==1.2\nDjango==1.7\nnose==1.3\n ' \
-            '-e http://example.com/some-repo.git\n ' \
-            'django-nose==1.0\n'
-        packages = _create_packages('mock==1.2\nDjango==1.7\nnose==1.3\n')
+    def test_run_remove_extra_packages_dry_run(self, mock_check_call, mock_check_output):
+        mock_check_output.return_value = 'mock==1.2\nDjango==1.7\nnose==1.3\ndjango-nose==1.0\n'
+        package_file = tempfile.NamedTemporaryFile()
+        package_file.write(b'mock==1.2\nDjango==1.7\nnose==1.3\n')
+        package_file.seek(0)
+        self.command.args = self.parser.parse_args(['-xn', package_file.name])
 
-        self.command.remove_extra_packages(packages)
+        self.command.run()
 
-        mock_check_call.assert_called_once_with(['pip', 'uninstall', '-y', 'django-nose'])
+        expected = "The following packages would be removed:\n    django-nose"
+        self.assertEqual(expected, sys.stdout.getvalue().strip())
+        self.assertFalse(mock_check_call.called)
 
     @patch('subprocess.check_output')
     @patch('subprocess.check_call')


### PR DESCRIPTION
1. I wanted this to work with `--upgrade` too, but the implementation doesn't really support it.  Should `pip install` ever gain a dry-run option, it'll be easy to add it to pipreq
2. I'm not totally happy with the tests now.  There's enough commonality that I really want to factor something out -- but enough difference that I don't see a way to do that.  Suggestions are more than welcome :-)
